### PR TITLE
Release 1.0.3

### DIFF
--- a/ConfigClassToJsonC/ConfigClassToJsonC/ConfigClassToJsonC.csproj
+++ b/ConfigClassToJsonC/ConfigClassToJsonC/ConfigClassToJsonC.csproj
@@ -16,11 +16,11 @@
         <PackageReleaseNotes>This is the first release, and may be the only release. There is a formatting issue inherint to the System.Text.Json namespace that causes commas meant for the value that was just written to be serialized at the end of the comment intended for the next JSON property. It is still highly readable and has no impact on the validity of the serialized JSONC. When Microsoft updates the library to fix this behavior, I will release a new version.</PackageReleaseNotes>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <Company>iAm9001</Company>
-        <ApplicationIcon>CC2JSONC-transparent.ico</ApplicationIcon>
         <IncludeBuildOutput>true</IncludeBuildOutput>
-        <DevelopmentDependency>true</DevelopmentDependency>
+        <DevelopmentDependency>false</DevelopmentDependency>
         <Configurations>Debug;Release;Release-Sign</Configurations>
         <Platforms>AnyCPU</Platforms>
+        <PackageLicenseUrl>https://github.com/iAm9001/ConfigClassToJsonC/blob/main/LICENSE</PackageLicenseUrl>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
@@ -31,9 +31,6 @@
         <Optimize Condition=" '$(Optimize)' == '' ">true</Optimize>
     </PropertyGroup>
 
-    <ItemGroup>
-        <Content Include="CC2JSONC-transparent.ico"/>
-    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">


### PR DESCRIPTION
Fixes development dependency setting for NuGet package. Library should now be available to applications / projects that consume it via NuGet (namespace was unavailable previously).